### PR TITLE
Pc add workflow to publish storybook CI/CD, both a production version and a QA version

### DIFF
--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -1,0 +1,29 @@
+
+name: Publish docs (Storybook) to GitHub Pages QA
+on: 
+  pull_request:
+    branches:
+      - main
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Install and Build 🔧
+        working-directory: ./frontend
+        run: | # Install npm packages and build the Storybook files
+          npm install
+          mkdir -p docs-build
+          npm run build-storybook
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          repository-name: ${{ github.repository }}-docs-qa
+          token: ${{ secrets.TOKEN }}
+          branch: main # The branch the action should deploy to.
+          folder: frontend/docs-build # The folder that the build-storybook script generates files.
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: docs/storybook # The folder that we serve our Storybook files from 

--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: ./frontend
         run: | # Install npm packages and build the Storybook files
           npm install
-          mkdir -p docs-build
+          mkdir -p storybook-static
           npm run build-storybook
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.0
@@ -24,6 +24,6 @@ jobs:
           repository-name: ${{ github.repository }}-docs-qa
           token: ${{ secrets.TOKEN }}
           branch: main # The branch the action should deploy to.
-          folder: frontend/docs-build # The folder that the build-storybook script generates files.
+          folder: frontend/storybook-static # The folder that the build-storybook script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: docs/storybook # The folder that we serve our Storybook files from 

--- a/.github/workflows/publish-docs-to-github-pages.yml
+++ b/.github/workflows/publish-docs-to-github-pages.yml
@@ -1,0 +1,29 @@
+
+name: Publish docs (Storybook) to GitHub Pages
+on: 
+  push:
+    branches:
+      - main
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - name: Install and Build 🔧
+        working-directory: ./frontend
+        run: | # Install npm packages and build the Storybook files
+          npm install
+          mkdir -p docs-build
+          npm run build-storybook
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          repository-name: ${{ github.repository }}-docs
+          token: ${{ secrets.TOKEN }}
+          branch: main # The branch the action should deploy to.
+          folder: frontend/docs-build # The folder that the build-storybook script generates files.
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: docs/storybook # The folder that we serve our Storybook files from 

--- a/.github/workflows/publish-docs-to-github-pages.yml
+++ b/.github/workflows/publish-docs-to-github-pages.yml
@@ -24,6 +24,6 @@ jobs:
           repository-name: ${{ github.repository }}-docs
           token: ${{ secrets.TOKEN }}
           branch: main # The branch the action should deploy to.
-          folder: frontend/docs-build # The folder that the build-storybook script generates files.
+          folder: frontend/storybook-static # The folder that the build-storybook script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: docs/storybook # The folder that we serve our Storybook files from 

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -1,3 +1,5 @@
+const WebpackPluginFailBuildOnWarning = require("./webpack-plugin-fail-build-on-warning");
+
 module.exports = {
   "stories": [
     "../src/**/*.stories.mdx",
@@ -7,5 +9,9 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/preset-create-react-app"
-  ]
+  ],
+  webpackFinal: async (config) => {
+    config.plugins.push(new WebpackPluginFailBuildOnWarning());
+    return config;
+  }
 }

--- a/frontend/.storybook/webpack-plugin-fail-build-on-warning.js
+++ b/frontend/.storybook/webpack-plugin-fail-build-on-warning.js
@@ -1,0 +1,71 @@
+// See: https://github.com/backstage/backstage/pull/721
+// See: https://github.com/backstage/backstage/blob/ad364bdf575a891ee43a0b49ff8cc1046f0f0bee/packages/storybook/.storybook/webpack-plugin-fail-build-on-warning.js
+
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * When building storybook, we can have warnings which may cause issues in the future. One of the example case is
+ * https://github.com/backstage/backstage/issues/718. To make sure new warnings are not introduced with new PRs, we
+ * want to fail CI builds if there are warnings when building storybook.
+ *
+ * This webpack plugin makes sure the CI builds fail on Webpack warnings. We also have an allowlist of warnings here
+ * which we think are non-critical.
+ *
+ * Note that this implementation will not detect other warnings emitted by storybook build that are separate from
+ * Webpack. A better solution over this plugin should be preferred, possibly on Storybook level (CLI options etc.)
+ *
+ * The case with #718 is caused because we are using `ts-loader` for `webpack` to load all our JS/TS files, but we
+ * have disabled type checking during build. This is done by setting `transpileOnly` to `true` in storybook/main.js
+ * and it improves the Storybook build speed. Because of this, Webpack emits warnings when we try to re-export types.
+ * Reference: https://github.com/TypeStrong/ts-loader#transpileonly
+ */
+class WebpackPluginFailBuildOnWarning {
+  // Ignore the following warnings in the Webpack build.
+  warningsAllowlist = new Set([
+    "AssetsOverSizeLimitWarning",
+    "EntrypointsOverSizeLimitWarning",
+    "NoAsyncChunksWarning",
+  ]);
+
+  /* Entry point for the Webpack plugin. */
+  apply(compiler) {
+    // Invoke plugin logic when Webpack build is 'done'.
+    compiler.hooks.done.tap("FailBuildOnWarning", this.execute.bind(this));
+  }
+
+  execute(stats) {
+    // All the compilation warnings are stored in stats.compilation.warnings
+    let warnings = stats.compilation.warnings;
+    if (warnings.length > 0) {
+      // Throw error if there are unexpected warnings.
+      for (let warning of warnings) {
+        if (!this.warningsAllowlist.has(warning.name)) {
+          process.on("beforeExit", () => {
+            console.log(
+              `You have some unexpected warning(s) in your webpack build. Exiting process as error.`
+            );
+            process.exit(1);
+          });
+          // No need to go over the rest of warnings from here.
+          break;
+        }
+      }
+    }
+  }
+}
+
+module.exports = WebpackPluginFailBuildOnWarning;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,8 +33,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "coverage": "react-scripts test --coverage --watchAll=false",
-    "storybook": "start-storybook -p 6006 -s public",
-    "build-storybook": "build-storybook -s public"
+    "storybook": "start-storybook --docs -p 6006 -s public",
+    "build-storybook": "build-storybook --docs -s public"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,12 +20,12 @@
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",
-    "@storybook/addon-actions": "^6.1.18",
-    "@storybook/addon-essentials": "^6.1.18",
-    "@storybook/addon-links": "^6.1.18",
-    "@storybook/node-logger": "^6.1.18",
-    "@storybook/preset-create-react-app": "^3.1.6",
-    "@storybook/react": "^6.1.18"
+    "@storybook/addon-actions": "^6.2.7",
+    "@storybook/addon-essentials": "^6.2.7",
+    "@storybook/addon-links": "^6.2.7",
+    "@storybook/node-logger": "^6.2.7",
+    "@storybook/preset-create-react-app": "^3.1.7",
+    "@storybook/react": "^6.2.7"
   },
   "scripts": {
     "start": "env-cmd -f ../.env -e development react-scripts start",


### PR DESCRIPTION
In this PR, we set up a GitHub workflow to publish the storybook for the repo.

The storybook is published on GitHub pages in two separate repos:
* https://github.com/happycows/demo-spring-react-kitchensink-docs for the production version of the documentation
  - Link to page: https://happycows.github.io/demo-spring-react-kitchensink-docs
  - Note that this page will NOT be updated until this PR is merged.
* https://github.com/happycows/demo-spring-react-kitchensink-docs-qa as a staging/qa site for draft versions contained in PRs
   - Link to page: https://happycows.github.io/demo-spring-react-kitchensink-docs-qa
   - This page should be active immediately 
   
One of the workflows is set up to publish to the production site, i.e. <https://ucsb-cs156-s21.github.io/proj-ucsb-cs-las-docs>, only on a push to the main branch (i.e. when a PR is merged.)

The other workflow is set up to publish to the QA branch any time there is a PR.  Note the implications: if there are multiple PRs outstanding, the contents of the qa GitHub pages site will always reflect the most recent PR that was made.   Teams will have to coordinate in order to review changes to the Storybook, so this is not a perfect solution. But it at least guarantees that if there are any problems with the publishing, those will get flagged as CI/CD errors, and it encourages teams to review the storybook before merging a PR.

The other sites need to be set up as follows:

First, add a file under `docs/index.md` that looks like this for the production docs site:

```
---
---

Documentation for <https://github.com/happycows/demo-spring-react-kitchensink>

[Storybook](storybook)


```

And like this for the qa docs site:

```
---
---

Documentation QA Site for <https://github.com/happycows/demo-spring-react-kitchensink>

* Documentation on this site is for work in progress.
* The production version of the documentation is here: <https://happycows.github.io/demo-spring-react-kitchensink-docs>

[Storybook](storybook)
```

Then, you can go to `Settings` for each of these repos, then `Pages` (near bottom of left nav) to enable GitHub Pages on the `main` branch and the `/docs` subdirectory.

It is also necessary to set up a Personal Access Token called `TOKEN` with scope `repo` and add it to the repository secrets.
