### PR TITLE
pc - allow logins from other than @ucsb.edu

### DIFF
--- a/src/main/java/edu/ucsb/cs156/kitchensink/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/kitchensink/controllers/UserInfoController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 @RestController
 public class UserInfoController extends ApiController {
-  @PreAuthorize("@currentUser.member")
+  @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("/currentUser")
   public User currentUser() {
     return super.currentUser();

--- a/src/main/java/edu/ucsb/cs156/kitchensink/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/kitchensink/entities/User.java
@@ -28,7 +28,4 @@ public class User {
   private String locale;
   private String hostedDomain;
 
-  public boolean isMember() {
-    return email.endsWith("@ucsb.edu");
-  }
 }

--- a/src/main/java/edu/ucsb/cs156/kitchensink/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/kitchensink/services/CurrentUserService.java
@@ -12,12 +12,4 @@ public abstract class CurrentUserService {
     return get() != null;
   }
 
-  public final boolean isMember() {
-    User user = get();
-    if (user == null) {
-      return false;
-    }
-
-    return user.isMember();
-  }
 }

--- a/src/test/java/edu/ucsb/cs156/kitchensink/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/kitchensink/controllers/UserInfoControllerTests.java
@@ -1,9 +1,9 @@
 package edu.ucsb.cs156.kitchensink.controllers;
 
 import edu.ucsb.cs156.kitchensink.ControllerTestCase;
-import edu.ucsb.cs156.kitchensink.entities.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -16,17 +16,10 @@ public class UserInfoControllerTests extends ControllerTestCase {
         .andExpect(status().is(403));
   }
 
+  @WithMockUser(roles={"USER"})
   @Test
   public void currentUser__logged_in() throws Exception {
-    loginAs(User.builder().email("test@ucsb.edu").build());
     mockMvc.perform(get("/api/currentUser"))
         .andExpect(status().isOk());
-  }
-
-  @Test
-  public void currentUser__logged_in_not() throws Exception {
-    loginAs(User.builder().email("test@google.com").build());
-    mockMvc.perform(get("/api/currentUser"))
-        .andExpect(status().is(403));
   }
 }


### PR DESCRIPTION
In this PR, we make a change that allows logins from Google accounts
other than those ending in @ucsb.edu.

This also removes the isMember feature, but we add that back in with a ROLE_MEMBER
using Spring Security in a different PR.