### PR TITLE
pc - update workflows for CI/CD to separate front and back end tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Backend Tests and Coverage (Java)
 
 on:
   push:
@@ -22,4 +22,10 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      env:
+        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
+      run: mvn -B test jacoco:report -Dskip.npm
+    - name: Upload to Codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/frontend-eslint.yml
+++ b/.github/workflows/frontend-eslint.yml
@@ -1,4 +1,4 @@
-name: ESLint
+name: ESLint (JavaScript style checking)
 
 on:
   pull_request:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,4 +1,4 @@
-name: Tests and Coverage
+name: Frontend Tests and Coverage (JavaScript)
 
 on:
   pull_request:
@@ -29,15 +29,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
         working-directory: ./frontend
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11.0.x
-      - name: Build with Maven
-        env:
-          TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-        run: mvn -B test jacoco:report -Dskip.npm
-      - name: Upload to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
+     

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # demo-spring-react-kitchensink: dsrk
 
+
 Storybook is here:
 * Production: <https://happycows.github.io/demo-spring-react-kitchensink-docs/>
 * QA:  <https://happycows.github.io/demo-spring-react-kitchensink-docs-qa/>
 
-# Setup before you run for the first time
+# Test setup
+
+For testing, you need to set a repository secret `TEST_PROPERTIES` to be the contents of `.env.SAMPLE`.   It is not necessary to have
+valid values for each of the environment variables, but if they are undefined, the tests will fail.
+
+# Setup before running application
 
 * Obtain a Google client id and client secret
-  - The callback url should be: `http://localhost:8080/login/oauth2/code/google`
+  - This is done at the Google Developer Console <https://console.cloud.google.com/> via the left navigation under `APIs and Services`, then `Credentials`, then `Create Credentials`
+  - The callback url should be: `http://localhost:8080/login/oauth2/code/google`.  (Note: `http` not `https` for localhost).
+  - You will also need to add a callback URL for Heroku if you are deploying there, e.g. `https://myappname.herokuapp.com/login/oauth2/code/google` (Note the `https` in the Heroku case.)
 
 
 # Getting Started on localhost


### PR DESCRIPTION
In this PR, we:
* Separate the CI/CD tests into frontend and backend in separate files (before, we were running backend tests twice)
* Label each job with more information about its purpose
* Add instructions to the README for setting up the TEST_PROPERTIES secret for backend tests
* Minor clarifications in Google OAuth setup instructions